### PR TITLE
Add linux sfmesh counter sf block store app

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ For more details about Service Fabric Mesh public preview in Azure, refer to thi
 
 This repository has two main folders:
 
-- [**src**](./src) contains source code samples. Some of these are built using the [Visual Studio Tools for Mesh](https://docs.microsoft.com/en-us/azure/service-fabric-mesh/service-fabric-mesh-howto-setup-developer-environment-sdk). Use these samples if you want to build the code from source, publish container images and deploy the app to Mesh.
+- **src** contains source code samples. Some of these are built using the [Visual Studio Tools for Mesh](https://docs.microsoft.com/en-us/azure/service-fabric-mesh/service-fabric-mesh-howto-setup-developer-environment-sdk). Use these samples if you want to build the code from source, publish container images and deploy the app to Mesh.
 
-- [**templates**](./templates) contains samples with ARM templates ready to deploy to Azure Mesh. Use these templates if you want to deploy an application using existing container images and deployment templates
+- **templates** contains samples with ARM templates ready to deploy to Azure Mesh. Use these templates if you want to deploy an application using existing container images and deployment templates
 
 Both folders contain instructions on how to work with the samples.
 

--- a/templates/counterSFVolumeDisk/sfvd_mesh_rp.linux.json
+++ b/templates/counterSFVolumeDisk/sfvd_mesh_rp.linux.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "location": {
+        "type": "string",
+        "metadata": {
+          "description": "Location of the resources (e.g. westus, eastus, westeurope)."
+        }
+      },
+      "stateFolderName": {
+        "type": "string",
+        "defaultValue": "CounterService",
+        "metadata": {
+          "description": "Folder in which to store the state. Provide a empty value to create a unique folder for each container to store the state. A non-empty value will retain the state across deployments, however if more than one applications are using the same folder, the counter may update more frequently."
+        }
+      }
+    },
+    "resources": [
+      {
+        "apiVersion": "2018-09-01-preview",
+        "name": "counterAppLinux",
+        "type": "Microsoft.ServiceFabricMesh/applications",
+        "location": "[parameters('location')]",
+        "dependsOn": [
+          "Microsoft.ServiceFabricMesh/networks/counterAppLinuxNetwork"
+        ],
+        "properties": {
+          "description": "Azure Service Fabric Mesh Counter Application using SFVolumeDisk.",
+          "services": [
+            {
+              "name": "counterService",
+              "properties": {
+                "description": "A web service that serves the counter value stored in SFVolumeDisk.",
+                "osType": "Linux",
+                "codePackages": [
+                  {
+                    "name": "counterService",
+                    "image": "seabreeze/azure-mesh-counter:0.1-alpine",
+                    "volumes": [
+                      {
+                        "name": "myvol",
+                        "creationParameters": {
+                          "kind": "ServiceFabricVolumeDisk",
+                          "sizeDisk": "Small"
+                        },
+                        "destinationPath": "/app/data"
+                      }
+                    ],
+                    "endpoints": [
+                      {
+                        "name": "counterServiceListener",
+                        "port": 80
+                      }
+                    ],
+                    "environmentVariables": [
+                      {
+                        "name": "STATE_FOLDER_NAME",
+                        "value": "[parameters('stateFolderName')]"
+                      }
+                    ],
+                    "resources": {
+                      "requests": {
+                        "cpu": 0.5,
+                        "memoryInGB": 0.5
+                      }
+                    }
+                  }
+                ],
+                "replicaCount": 1,
+                "networkRefs": [
+                  {
+                    "name": "[resourceId('Microsoft.ServiceFabricMesh/networks', 'counterAppLinuxNetwork')]"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2018-09-01-preview",
+        "name": "counterAppLinuxNetwork",
+        "type": "Microsoft.ServiceFabricMesh/networks",
+        "location": "[parameters('location')]",
+        "dependsOn": [],
+        "properties": {
+          "description": "Azure Service Fabric Mesh Counter Application network.",
+          "addressPrefix": "10.0.0.4/22",
+          "ingressConfig": {
+            "layer4": [
+              {
+                "name": "counterServiceIngress",
+                "publicPort": "80",
+                "applicationName": "counterAppLinux",
+                "serviceName": "counterService",
+                "endpointName": "counterServiceListener"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adds a service fabric block store SFMesh app.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  az mesh deployment create --resource-group sampleResourceGroup --template-file template-file-name.json --parameters "{'location': {'value': 'eastus'}}" 

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
* Deploy the app.
* Check that app is healthy.
```

## What to Check
Verify that the following are valid
* You can send request on port `80` to the container.

## Other Information
<!-- Add any other helpful information that may be needed here. -->