### PR TITLE
Updated image references to corresponding mcr equivalent

### DIFF
--- a/src/helloworld/windows/Dockerfile
+++ b/src/helloworld/windows/Dockerfile
@@ -1,5 +1,4 @@
-FROM microsoft/iis:windowsservercore-1709
-
+FROM mcr.microsoft.com/windows/servercore/iis:windowsservercore-1709
 RUN mkdir C:\site
 
 RUN powershell -NoProfile -Command \

--- a/src/todolistapp/ToDoService/Dockerfile
+++ b/src/todolistapp/ToDoService/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1803 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1803 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /src
 COPY ToDoService/ToDoService.csproj ToDoService/
 RUN dotnet restore ToDoService/ToDoService.csproj

--- a/src/todolistapp/WebFrontEnd/Dockerfile
+++ b/src/todolistapp/WebFrontEnd/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime-nanoserver-1803 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1803 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 WORKDIR /src
 COPY WebFrontEnd/WebFrontEnd.csproj WebFrontEnd/
 RUN dotnet restore WebFrontEnd/WebFrontEnd.csproj


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* To avoid docker throttling unauthenticated pulls, we've moved images previously hosted on dockerhub at microsoft/* to an MCR equivalent. This PR modifies image references to point to MCR. Notably, this PR does not include any Dotnet Core 2.0 references, as there is no equivalent in MCR. The intent is to update such references to Dotnet Core 2.1 in a separate PR as more testing needs to be done to ensure nothing breaks during the upgrade. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Addresses the impending issue of docker throttling unauthenticated pulls
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->