### PR TITLE
Upgraded dotnet 2.0 references to 2.1 mcr references

### DIFF
--- a/src/counter/src/counterService/Dockerfile
+++ b/src/counter/src/counterService/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/aspnetcore:2.0-nanoserver-1709 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1709 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 # Using sfvolume here does not matter as code files are in this directory.
 COPY sfvolume/counterService/counterService.csproj sfvolume/counterService/

--- a/src/counter/src/counterService/linux.Dockerfile
+++ b/src/counter/src/counterService/linux.Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 # Using sfvolume here does not matter as code files are in this directory.
 COPY sfvolume/counterService/counterService.csproj sfvolume/counterService/

--- a/src/visualobjects/web/Dockerfile
+++ b/src/visualobjects/web/Dockerfile
@@ -1,8 +1,8 @@
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 EXPOSE 8080
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY web/web.csproj web/
 RUN dotnet restore web/web.csproj

--- a/src/visualobjects/worker/Dockerfile
+++ b/src/visualobjects/worker/Dockerfile
@@ -1,7 +1,7 @@
-FROM microsoft/dotnet:2.0-runtime AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 
-FROM microsoft/dotnet:2.0-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY worker/worker.csproj worker/
 RUN dotnet restore worker/worker.csproj

--- a/src/visualobjects/worker/rotate.Dockerfile
+++ b/src/visualobjects/worker/rotate.Dockerfile
@@ -1,7 +1,7 @@
-FROM microsoft/dotnet:2.0-runtime AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 
-FROM microsoft/dotnet:2.0-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY worker/worker.csproj worker/
 RUN dotnet restore worker/worker.csproj

--- a/src/votingapp/linux/Dockerfile-data
+++ b/src/votingapp/linux/Dockerfile-data
@@ -1,7 +1,7 @@
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY VotingData/VotingData.csproj VotingData/
 RUN dotnet restore VotingData/VotingData.csproj

--- a/src/votingapp/linux/Dockerfile-web
+++ b/src/votingapp/linux/Dockerfile-web
@@ -1,8 +1,8 @@
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 EXPOSE 9072
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY VotingWeb/VotingWeb.csproj VotingWeb/
 RUN dotnet restore VotingWeb/VotingWeb.csproj

--- a/src/votingapp/linux/VotingData/Dockerfile
+++ b/src/votingapp/linux/VotingData/Dockerfile
@@ -1,7 +1,7 @@
-FROM microsoft/aspnetcore:2.0 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1 AS base
 WORKDIR /app
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY VotingData/VotingData.csproj VotingData/
 RUN dotnet restore VotingData/VotingData.csproj

--- a/src/votingapp/windows/VotingApp/VotingData/Dockerfile
+++ b/src/votingapp/windows/VotingApp/VotingData/Dockerfile
@@ -1,7 +1,7 @@
-FROM microsoft/aspnetcore:2.0-nanoserver-1709 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1709 AS base
 WORKDIR /app
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY VotingData/VotingData.csproj VotingData/
 RUN dotnet restore VotingData/VotingData.csproj

--- a/src/votingapp/windows/VotingApp/VotingWeb/Dockerfile
+++ b/src/votingapp/windows/VotingApp/VotingWeb/Dockerfile
@@ -1,7 +1,7 @@
-FROM microsoft/aspnetcore:2.0-nanoserver-1709 AS base
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-nanoserver-1709 AS base
 WORKDIR /app
 
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
 WORKDIR /src
 COPY VotingWeb/VotingWeb.csproj VotingWeb/
 RUN dotnet restore VotingWeb/VotingWeb.csproj


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* To avoid docker throttling unauthenticated pulls, we've moved images previously hosted on dockerhub at microsoft/* to an MCR equivalent. This PR **DOES** include an upgrade of Dotnet Core 2.0 references to 2.1. Please do not merge this PR until testing has been done to ensure no breaking changes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: Addresses the impending issue of docker throttling unauthenticated pulls
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->