### PR TITLE
Added readme's with rate limiting guidance

### DIFF
--- a/src/counter/README.md
+++ b/src/counter/README.md
@@ -1,0 +1,15 @@
+## Counter
+
+Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+
+This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
+
+| Source                      | Image   |
+| -------------               |-------------|
+| src/counterService/Dockerfile       | microsoft/aspnetcore:2.0-nanoserver-1709       |
+|| microsoft/aspnetcore-build:2.0|
+| src/counterService/linux.Dockerfile | microsoft/aspnetcore:2.0|
+|| microsoft/aspnetcore-build:2.0|
+| sfvolume/counter/linux/App Resources/app.yaml    | seabreeze/azure-mesh-counter:0.5-alpine|
+
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/counter/README.md
+++ b/src/counter/README.md
@@ -1,6 +1,6 @@
 ## Counter
 
-Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+Effective November 2, 2020, [download rate limits apply](https://docs.docker.com/docker-hub/download-rate-limit/) to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
 
 This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
 
@@ -12,4 +12,4 @@ This sample pulls the following public images from Docker Hub. Please note that 
 || microsoft/aspnetcore-build:2.0|
 | sfvolume/counter/linux/App Resources/app.yaml    | seabreeze/azure-mesh-counter:0.5-alpine|
 
-For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/helloworld/README.md
+++ b/src/helloworld/README.md
@@ -1,0 +1,12 @@
+## Hello World
+
+Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+
+This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
+
+| Source                      | Image   |
+| -------------               |-------------|
+| linux/main/Dockerfile       | nginx       |
+| linux/sidecar/Dockerfile    | busybox:musl|
+
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/helloworld/README.md
+++ b/src/helloworld/README.md
@@ -1,6 +1,6 @@
 ## Hello World
 
-Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+Effective November 2, 2020, [download rate limits apply](https://docs.docker.com/docker-hub/download-rate-limit/) to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
 
 This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
 
@@ -9,4 +9,4 @@ This sample pulls the following public images from Docker Hub. Please note that 
 | linux/main/Dockerfile       | nginx       |
 | linux/sidecar/Dockerfile    | busybox:musl|
 
-For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/visualobjects/README.md
+++ b/src/visualobjects/README.md
@@ -1,6 +1,6 @@
 ## Visual Objects
 
-Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+Effective November 2, 2020, [download rate limits apply](https://docs.docker.com/docker-hub/download-rate-limit/) to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
 
 This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
 
@@ -13,4 +13,4 @@ This sample pulls the following public images from Docker Hub. Please note that 
 | worker/rotate.Dockerfile| microsoft/dotnet:2.0-runtime|
 || microsoft/dotnet:2.0-sdk|
 
-For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/visualobjects/README.md
+++ b/src/visualobjects/README.md
@@ -1,0 +1,16 @@
+## Visual Objects
+
+Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+
+This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
+
+| Source                      | Image   |
+| -------------               |-------------|
+| web/Dockerfile       | microsoft/aspnetcore:2.0       |
+|| microsoft/aspnetcore-build:2.0|
+| worker/Dockerfile| microsoft/dotnet:2.0-runtime|
+|| microsoft/dotnet:2.0-sdk|
+| worker/rotate.Dockerfile| microsoft/dotnet:2.0-runtime|
+|| microsoft/dotnet:2.0-sdk|
+
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/votingapp/README.md
+++ b/src/votingapp/README.md
@@ -1,0 +1,20 @@
+## Voting App
+
+Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+
+This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
+
+| Source                      | Image   |
+| -------------               |-------------|
+| windows/VotingApp/VotingData/Dockerfile       | microsoft/aspnetcore:2.0-nanoserver-1709       |
+|| microsoft/aspnetcore-build:2.0|
+| windows/VotingApp/VotingWeb/Dockerfile| microsoft/aspnetcore:2.0-nanoserver-1709|
+|| microsoft/aspnetcore-build:2.0|
+| linux/Dockerfile-data   | microsoft/aspnetcore:2.0|
+|| microsoft/aspnetcore-build:2.0|
+| linux/Dockerfile-web| microsoft/aspnetcore:2.0|
+|| microsoft/aspnetcore-build:2.0|
+| linux/VotingData/Dockerfile       | microsoft/aspnetcore:2.0       |
+|| microsoft/aspnetcore-build:2.0|
+
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).

--- a/src/votingapp/README.md
+++ b/src/votingapp/README.md
@@ -1,6 +1,6 @@
 ## Voting App
 
-Effective November 2, 2020, download rate limits apply to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
+Effective November 2, 2020, [download rate limits apply](https://docs.docker.com/docker-hub/download-rate-limit/) to anonymous and authenticated requests to Docker Hub from Docker Free plan accounts and are enforced by IP address.
 
 This sample pulls the following public images from Docker Hub. Please note that you may be rate limited.
 
@@ -17,4 +17,4 @@ This sample pulls the following public images from Docker Hub. Please note that 
 | linux/VotingData/Dockerfile       | microsoft/aspnetcore:2.0       |
 || microsoft/aspnetcore-build:2.0|
 
-For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/en-us/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).
+For more details, see [Authenticate with Docker Hub](https://docs.microsoft.com/azure/container-registry/buffer-gate-public-content#authenticate-with-docker-hub).


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* To avoid docker throttling unauthenticated pulls, we've moved images previously hosted on dockerhub at microsoft/* to an MCR equivalent. This PR adds README's in repositories still making use of public images with guidance on rate limiting. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->